### PR TITLE
Adding SASL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ New features (compared to ii):
 * Support for [IRCv3.2 monitoring][ircv3.2 monitor]
 * Support for a per-channel nick list using a UNIX domain socket
 * Support for recording messages mentioning the users
+* Supporting SASL authentication
 * Built-in TLS support
 * Built-in IPv6 support
 

--- a/hii.go
+++ b/hii.go
@@ -132,8 +132,8 @@ func parseFlags() {
 	flag.BoolVar(&useTLS, "t", false, "use TLS")
 	flag.BoolVar(&debug, "d", false, "enable debug output")
 	flag.BoolVar(&useSASL, "s", false, "use SASL")
-	flag.StringVar(&saslUid, "u", "", "real name")
-	flag.StringVar(&saslPwd, "w", "", "real name")
+	flag.StringVar(&saslUid, "u", "", "SASL username")
+	flag.StringVar(&saslPwd, "w", "", "SASL password")
 
 	flag.Usage = usage
 	flag.Parse()

--- a/hii.go
+++ b/hii.go
@@ -59,6 +59,9 @@ var (
 	nick       string
 	port       int
 	useTLS     bool
+	useSASL    bool
+	saslUid    string
+	saslPwd    string
 	debug      bool
 )
 
@@ -128,6 +131,9 @@ func parseFlags() {
 	flag.IntVar(&port, "p", 6667, "TCP port")
 	flag.BoolVar(&useTLS, "t", false, "use TLS")
 	flag.BoolVar(&debug, "d", false, "enable debug output")
+	flag.BoolVar(&useSASL, "s", false, "use SASL")
+	flag.StringVar(&saslUid, "u", "", "real name")
+	flag.StringVar(&saslPwd, "w", "", "real name")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -143,6 +149,9 @@ func parseFlags() {
 	}
 	if (clientKey != "" || clientCert != "" || certs != "") && !useTLS {
 		log.Fatal("certificates given but TLS wasn't enabled")
+	}
+	if (saslUid != "" || saslPwd != "" ) && !useSASL {
+		log.Fatal("SASL credentials given but SASL wasn't enabled")
 	}
 }
 
@@ -713,6 +722,10 @@ func newClient() (*girc.Client, error) {
 		SSL:        useTLS,
 		TLSConfig:  tlsconf,
 		DisableSTS: true,
+	}
+	
+	if useSASL {
+		config.SASL = &girc.SASLPlain{User: saslUid, Pass: saslPwd}
 	}
 
 	client := girc.New(config)


### PR DESCRIPTION
These changes add SASL support to hii. If you activate SASL by using the new flag -s and add a username and password (with -u and -w), hii will log in to your IRC server using SASL authentication as tested with Ergo ircd.